### PR TITLE
Adding"clear functions" to runMlSelection function

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,6 +161,7 @@ export function activate(context: vscode.ExtensionContext) {
 			fs.writeFileSync(tempPath, current_selection);
 			if (activeTerminal && activeTerminal.name === "Matlab REPL") // If already a Matlab Engine started, the selection is run in it
 			{
+				activeTerminal.sendText("clear functions"); // Force Matlab to reload the scripts
 				activeTerminal.sendText(util.format("run(\"%s\")", tempPath));
 				activeTerminal.show(false);
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -161,7 +161,7 @@ export function activate(context: vscode.ExtensionContext) {
 			fs.writeFileSync(tempPath, current_selection);
 			if (activeTerminal && activeTerminal.name === "Matlab REPL") // If already a Matlab Engine started, the selection is run in it
 			{
-				activeTerminal.sendText("clear functions"); // Force Matlab to reload the scripts
+				activeTerminal.sendText(util.format("clear(\"%s\")", tempPath)); // Force Matlab to reload the scripts
 				activeTerminal.sendText(util.format("run(\"%s\")", tempPath));
 				activeTerminal.show(false);
 			}


### PR DESCRIPTION
I  encountered problem [#12 ](https://github.com/apommel/vscode-matlab-interactive-terminal/issues/12) on my computer. I read through the extension source code, and did some tests, and found the cause of the problem: "run temp.m file" command in `runMlSelection`may execute a cached file, and adding `clear functions` like `runMlScript`  will solve the problem. This method works on my computer.
