### PR TITLE
Adding a 'Cursor Back' option

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 				"matlab-interactive-terminal.CursorBack":{
 					"type":"boolean",
 					"default":"true",
-					"description": "Deciding whether to make the cursor fall back onto your editor when you excute the command 'Run Current Selection' "
+					"description": "Decides whether to make the cursor fall back onto your editor when you execute the command 'Run current selection' "
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
 					"type": "boolean",
 					"default": "false",
 					"description": "Displays unicode characters (ex: CJK characters) in Matlab output (N.B.: output will not be in real time)"
+				},
+				"matlab-interactive-terminal.CursorBack":{
+					"type":"boolean",
+					"default":"true",
+					"description": "Deciding whether to make the cursor fall back onto your editor when you excute the command 'Run Current Selection' "
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,9 @@ export function activate(context: vscode.ExtensionContext) {
 			{
 				activeTerminal.sendText(util.format("clear(\"%s\")", tempPath)); // Force Matlab to reload the scripts
 				activeTerminal.sendText(util.format("run(\"%s\")", tempPath));
-				activeTerminal.show(false);
+				if (vscode.workspace.getConfiguration("matlab-interactive-terminal").get("CursorBack")===false) {
+					activeTerminal.show(false);
+				}
 			}
 			else {
 				python_path = getPythonPath();


### PR DESCRIPTION
As stated here https://github.com/apommel/vscode-matlab-interactive-terminal/issues/23#issue-718647076, I made it optional whether to make the cursor leave the editor text or just stay when executing "Run current selection".