### PR TITLE
Run code block

### DIFF
--- a/Test-Run-Code-Block.m
+++ b/Test-Run-Code-Block.m
@@ -1,0 +1,11 @@
+%% The extension "weihongliang233.code-block" requiers that the first line in the editor should not be the splitor.
+1+1
+
+%**%
+disp("This is the 2th block")
+
+%**%
+disp("This is the 3rd block")
+
+%**%
+plot(sin([1:0.01:10]))

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
 					"type": "boolean",
 					"default": "false",
 					"description": "Displays unicode characters (ex: CJK characters) in Matlab output (N.B.: output will not be in real time)"
+				},
+				"matlab-interactive-terminal.CursorBack":{
+					"type":"boolean",
+					"default":"true",
+					"description": "Deciding whether to make the cursor fall back onto your editor when you excute the command 'Run Current Selection' "
 				}
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 	"activationEvents": [
 		"onCommand:extension.openMatlabTerminal",
 		"onCommand:extension.runMatlabScript",
-		"onCommand:extension.runMatlabSelection"
+		"onCommand:extension.runMatlabSelection",
+		"onCommand:extension.runCurrentBlock"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -36,6 +37,10 @@
 			{
 				"command": "extension.runMatlabSelection",
 				"title": "Run current selection in Matlab"
+			},
+			{
+				"command": "extension.runCurrentBlock",
+				"title": "Run current block in Matlab"
 			}
 		],
 		"configuration": {
@@ -57,6 +62,10 @@
 					"description": "Decides whether to make the cursor fall back onto your editor when you execute the command 'Run current selection' "
 				}
 			}
+		},
+		"keybindings":{
+			"command": "extension.runCurrentBlock",
+			"key": "ctrl+enter"
 		}
 	},
 	"scripts": {
@@ -77,5 +86,8 @@
 		"typescript": "^3.9.7",
 		"vscode-test": "^1.4.0"
 	},
-	"dependencies": {}
+	"dependencies": {},
+	"extensionDependencies": [
+		"weihongliang233.code-block"
+	]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,9 @@ export function activate(context: vscode.ExtensionContext) {
 			{
 				activeTerminal.sendText(util.format("clear(\"%s\")", tempPath)); // Force Matlab to reload the scripts
 				activeTerminal.sendText(util.format("run(\"%s\")", tempPath));
-				activeTerminal.show(false);
+				if (vscode.workspace.getConfiguration("matlab-interactive-terminal").get("CursorBack")===false) {
+					activeTerminal.show(false);
+				}
 			}
 			else {
 				python_path = getPythonPath();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,6 +187,18 @@ export function activate(context: vscode.ExtensionContext) {
 	};
 	context.subscriptions.push(vscode.commands.registerCommand('extension.runMatlabSelection', runMlSelection));
 
+	const runCurrentBlock=()=>{
+		var code_block_extension =  vscode.extensions.getExtension("weihongliang233.code-block");
+		if(code_block_extension){
+			vscode.commands.executeCommand("code-block.selectCurrentBlock");
+			runMlSelection();
+		}
+		else{
+			vscode.window.showErrorMessage('Extension "weihongliang233.code-block" not installed');
+		}
+		
+	};
+	context.subscriptions.push(vscode.commands.registerCommand('extension.runCurrentBlock',runCurrentBlock));
 }
 
 // this method is called when your extension is deactivated


### PR DESCRIPTION
# Implemented "Run Code Block" functionality

I have developed an extension ([on Github](https://github.com/weihongliang233/code-block)  on [in VScodeExtension Marketplace](https://marketplace.visualstudio.com/search?term=weihongliang233&target=VSCode&category=All%20categories&sortBy=Relevance) ) which can split the code file into blocks with regular expression and manipulate with the blocks. One can highlight the current block (where the cursor points at), quickly navigate through blocks and select a whole block (more functionalities are coming soon). 

I have integrated its "select the whole current block" functionality into this matlab-interactive-terminal extension. There is already an [issue ](https://github.com/apommel/vscode-matlab-interactive-terminal/issues/13) here. The following gif is a demo:

![demo2](https://gitee.com/wei_hong_liang/My_Picture_Bed/raw/master/20201018231917.gif)

