### PR TITLE
Fixed bad characters

### DIFF
--- a/interfaces/standard/check_dependencies.py
+++ b/interfaces/standard/check_dependencies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 # Checks if the necessary Python dependencies are present on the system at activation
 try: # Check if the Matlab Engine is installed

--- a/interfaces/standard/matlab_interface.py
+++ b/interfaces/standard/matlab_interface.py
@@ -1,7 +1,8 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 # Trying to have a basic Python 2 compatibility
 from __future__ import print_function
+
 try:
     input = raw_input
 except NameError:

--- a/interfaces/standard/ml_script.py
+++ b/interfaces/standard/ml_script.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 from matlab_interface import MatlabInterface
 import sys

--- a/interfaces/standard/ml_selection.py
+++ b/interfaces/standard/ml_selection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 from matlab_interface import MatlabInterface
 import sys

--- a/interfaces/standard/ml_terminal.py
+++ b/interfaces/standard/ml_terminal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 from matlab_interface import MatlabInterface
 

--- a/interfaces/unicode/check_dependencies.py
+++ b/interfaces/unicode/check_dependencies.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 # Checks if the necessary Python dependencies are present on the system at activation
 try: # Check if the Matlab Engine is installed

--- a/interfaces/unicode/matlab_interface.py
+++ b/interfaces/unicode/matlab_interface.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 # Trying to have a basic Python 2 compatibility
 from __future__ import print_function

--- a/interfaces/unicode/ml_script.py
+++ b/interfaces/unicode/ml_script.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 from matlab_interface import MatlabInterface
 import sys

--- a/interfaces/unicode/ml_selection.py
+++ b/interfaces/unicode/ml_selection.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 from matlab_interface import MatlabInterface
 import sys

--- a/interfaces/unicode/ml_terminal.py
+++ b/interfaces/unicode/ml_terminal.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Aurélien Pommel
+# Copyright (c) 2020 Aurelien Pommel
 
 from matlab_interface import MatlabInterface
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -62,7 +62,7 @@ export function activate(context: vscode.ExtensionContext) {
 			}
 		}
 		catch (error) { // If an error is caught, it means Python cannot be called
-			err_message = "Python is not installed or its path is incorrectly specified";
+			err_message = error.message;
 			checked_setup = false;
 		}
 		return (checked_setup);


### PR DESCRIPTION
Silly that python can't handle this character, but this fixes #14.

Also made the `checkSetup` function more verbose towards errors stemming from `execFileSync`. (Perhaps this should be exec, or spawn as well to be more in-line with JS conventions?)