### PR TITLE
Restore delayed activation (`onTerminalProfile` event)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
 		"Other"
 	],
 	"activationEvents": [
-		"onStartupFinished"
+		"onLanguage:matlab",
+		"onCommand:matlab-interactive-terminal.openMatlabTerminal",
+		"onCommand:matlab-interactive-terminal.runMatlabScript",
+		"onCommand:matlab-interactive-terminal.runMatlabSelection",
+		"onTerminalProfile:matlab-interactive-terminal.terminal-profile"
 	],
 	"main": "./out/extension.js",
 	"contributes": {


### PR DESCRIPTION
Resolves https://github.com/apommel/vscode-matlab-interactive-terminal/pull/37#issuecomment-894767017.